### PR TITLE
Remove mention of TODO file

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,6 @@ If email is better for you, [my address is mentioned below](#author) but I
 would rather have bugs sent through the issue tracker found at
 http://github.com/sanko/readonly/issues.
 
-Please check the TODO file included with this distribution in case your bug
-is already known (...I probably won't file bug reports to myself).
-
 # Acknowledgements
 
 Thanks to Slaven Rezic for the idea of one common function (Readonly) for all


### PR DESCRIPTION
The TODO file itself was removed here:

```
commit 62378533298754a9cb9475813124c6c9f1c174b0
Author: Sanko Robinson <sanko@cpan.org>
Date:   Mon Jun 30 06:47:59 2014 -0400

    Deprecation of Readonly::XS as a requirement on modern perl is complete

    - Removing TODO
    - Major version bump to undo my screw up
```
