### PR TITLE
Fix for issue 18: Readonly my $foo = 2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for Perl extension Readonly.
 
 {{$NEXT}}
+    - Disallow initialization of Readonly variables by assignment
+      allowed by Perl prototype changes in v5.16.  Assignment initialization
+      of scalars sets scalar variables to undef and lists and hashes
+      initialized by assignment are not read only.
+
+2.00 2014-06-30T11:15:05Z
     - Deprecation of Readonly::XS as a requirement for fast, readonly
       scalars is complete. Report any lingering issues on the tracker
       ASAP.

--- a/lib/Readonly.pm
+++ b/lib/Readonly.pm
@@ -5,7 +5,7 @@ use strict;
 #use warnings;
 #no warnings 'uninitialized';
 package Readonly;
-our $VERSION = '2.00';
+our $VERSION = '2.01';
 $VERSION = eval $VERSION;
 
 # Autocroak (Thanks, MJD)
@@ -298,6 +298,11 @@ eval q{sub Readonly} . ($] < 5.008 ? '' : '(\[$@%]@)') . <<'SUB_READONLY';
         my $badtype = _is_badtype (ref tied ${$_[0]});
         croak "$REASSIGN $badtype" if $badtype;
         croak "Readonly scalar must have only one value" if @_ > 2;
+
+        # Because of problems with handling \$ prototypes declarations like
+        # Readonly my @a = ... and Readonly my %h = ... are also caught here
+        croak 'Invalid initialization by assignment'
+            if @_ == 1 && defined ${$_[0]};
 
         my $tieobj = eval {tie ${$_[0]}, 'Readonly::Scalar', $_[1]};
         # Tie may have failed because user tried to tie a constant, or we screwed up somehow.

--- a/t/bugs/001_assign.t
+++ b/t/bugs/001_assign.t
@@ -11,6 +11,10 @@ use constant ASSIGNMENT_ERR => qr/
 # Find the module (1 test)
 BEGIN { use_ok('Readonly'); }
 
+SKIP:
+{
+    skip 'Readonly $@% syntax is for perl 5.8 or later', 8  unless $] >= 5.008;
+
 eval 'Readonly my $simple = 2;';
 like $@ => ASSIGNMENT_ERR, 'Reject scalar initialization by assignment';
 
@@ -38,3 +42,4 @@ eval 'Readonly my %h; $h{key} = "v";';
 like $@ => qr/Modification of a read-only/,
     'Readonly empty hash is read only';
 
+}

--- a/t/bugs/001_assign.t
+++ b/t/bugs/001_assign.t
@@ -1,0 +1,37 @@
+#!perl -I../../lib
+# Verify the Readonly function rejects initialization by assignment
+use strict;
+use Test::More tests => 9;
+
+use constant ASSIGNMENT_ERR => qr/Invalid initialization by assignment/;
+
+# Find the module (1 test)
+BEGIN { use_ok('Readonly'); }
+
+eval 'Readonly my $simple = 2;';
+like $@ => ASSIGNMENT_ERR, 'Reject scalar initialization by assignment';
+
+eval 'Readonly my @a = (3, 5);';
+like $@ => ASSIGNMENT_ERR,
+    'Reject array initialization by assignment';
+
+eval 'Readonly my %h = (key => 42);';
+like $@ => ASSIGNMENT_ERR,
+    'Reject hash initialization by assignment';
+
+eval 'Readonly my %h = {key => 42};';
+like $@ => ASSIGNMENT_ERR,
+    'Reject hash initialization by assignment to hash ref';
+
+eval 'Readonly my @a;';
+is $@ => '', 'Readonly empty array OK';
+eval 'Readonly my @a; $a[0] = 2;';
+like $@ => qr/Modification of a read-only/,
+    'Readonly empty array is read only';
+
+eval 'Readonly my %h;';
+is $@ => '', 'Readonly empty hash OK';
+eval 'Readonly my %h; $h{key} = "v";';
+like $@ => qr/Modification of a read-only/,
+    'Readonly empty hash is read only';
+

--- a/t/bugs/001_assign.t
+++ b/t/bugs/001_assign.t
@@ -3,7 +3,10 @@
 use strict;
 use Test::More tests => 9;
 
-use constant ASSIGNMENT_ERR => qr/Invalid initialization by assignment/;
+use constant ASSIGNMENT_ERR => qr/
+    \QInvalid initialization by assignment\E | # added by patch
+    \QType of arg 1 to Readonly::Readonly must be one of\E # pre v5.16
+/x;
 
 # Find the module (1 test)
 BEGIN { use_ok('Readonly'); }

--- a/t/bugs/001_assign.t
+++ b/t/bugs/001_assign.t
@@ -4,7 +4,7 @@ use strict;
 use Test::More tests => 9;
 
 use constant ASSIGNMENT_ERR => qr/
-    \QInvalid initialization by assignment\E | # added by patch
+    \QInvalid initialization by assignment\E | # Readonly assignment patch
     \QType of arg 1 to Readonly::Readonly must be one of\E # pre v5.16
 /x;
 

--- a/t/bugs/007_implicit_undef.t
+++ b/t/bugs/007_implicit_undef.t
@@ -11,8 +11,12 @@ sub expected {
 
 # Find the module (1 test)
 BEGIN { use_ok('Readonly'); }
+SKIP:
+{
+    skip 'Readonly $@% syntax is for perl 5.8 or later', 1  unless $] >= 5.008;
 eval 'Readonly my $simple;';
 is $@ => '', 'Simple API allows for implicit undef values';
+}
 eval q'Readonly::Scalar my $scalar;';
 like $@ => qr[Not enough arguments for Readonly::Scalar],
     'Readonly::Scalar does not allow implicit undef values';


### PR DESCRIPTION
As noted in the comments for [issue 18](https://github.com/sanko/readonly/issues/18), the patch disallows assignment initialization for scalars, arrays **and** hashes because assignment initialization leaves scalars undef and arrays and hashes initialized by assignment may be initialized correctly but are not read only.

The patch has been tested under the following environments:
Perl 5.22.1 Cygwin
Perl 5.22.0 Windows 7
Perl 5.16.3 Ubuntu Linux
Perl 5.14.2 Ubuntu Linux
Perl 5.6.2 Ubuntu Linux

Best wishes,
Ron Schmidt