### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,29 @@ debugging tool for catching updates to variables that should not be changed.
 
 Readonly has the ability to create both deep and shallow readonly variables.
 
-If any of the values you pass to `Scalar`, `Array`, `Hash`, or the standard
-`Readonly` are references, then those functions recurse over the data
-structures, marking everything as Readonly. The entire structure is
-nonmodifiable. This is normally what you want.
+If you pass a `$ref`, an `@array` or a `%hash` to corresponding functions `::Scalar()`, `::Array()` and `::Hash()`, then those functions recurse over the data structure, marking everything as Readonly. The entire structure is then non-modifiable. This is normally what you want.
 
 If you want only the top level to be Readonly, use the alternate (and poorly
-named) `Scalar1`, `Array1`, and `Hash1` functions.
+named) `::Scalar1()`, `::Array1()`, and `::Hash1()` functions.
+
+Plain `Readonly()` creates what the original author calls a "shallow" read only variable, which is great if you don't plan to use it on anything but one dimensional scalar values.
+
+`Readonly::Scalar()` makes the variable 'deeply' read only, so the following snippet kills over as you expect:
+```
+use Readonly;
+
+Readonly::Scalar my $ref => { 1 => 'a' };
+$ref->{1} = 'b';
+$ref->{2} = 'b';
+```
+While the following snippet does **not** make your structure 'deeply' read only:
+```
+use Readonly;
+
+Readonly my $ref => { 1 => 'a' };
+$ref->{1} = 'b';
+$ref->{2} = 'b';
+```
 
 # 
 


### PR DESCRIPTION
Change a "Variable Depth" section of the `README.md` to avoid a misinterpretation.
It should also work around [this issue](https://github.com/sanko/readonly/issues/12).