### PR TITLE
Mention uppercase for RO variable names based PBP, Perl::Critic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Readonly - Facility for creating read-only scalars, arrays, hashes
     Readonly    \%has => (key => value, key => value, ...);
     Readonly \my %has => (key => value, key => value, ...);
 
+    # Some Perl style guides (Perl::Critic, PBP) recommend uppercase
+    Readonly my $PI => 4 * atan2 1, 1;
+
 # Description
 
 This is a facility for creating non-modifiable variables. This is useful for

--- a/lib/Readonly.pm
+++ b/lib/Readonly.pm
@@ -500,6 +500,9 @@ Readonly - Facility for creating read-only scalars, arrays, hashes
     Readonly    \%has => (key => value, key => value, ...);
     Readonly \my %has => (key => value, key => value, ...);
 
+    # Some Perl style guides (Perl::Critic, PBP) recommend uppercase
+    Readonly my $PI => 4 * atan2 1, 1;
+
 =head1 Description
 
 This is a facility for creating non-modifiable variables. This is useful for


### PR DESCRIPTION
All the examples in the Readme documentation use lowercase naming.  There are recommendations from more recent and reasonably authoritative sources that suggest uppercase naming including Perl Best Practices (pages 45, 55-58), Perl::Critic, and arguably Programming Perl 4th ed (page 1013 on constants).  Adding mention of use of uppercase for Readonly variable names may be helpful.