### PR TITLE
benchmark.pl: There is no $code->{roxs}

### DIFF
--- a/eg/benchmark.pl
+++ b/eg/benchmark.pl
@@ -78,6 +78,6 @@ my $code = {const     => \&const,
 };
 unless ($Readonly::XSokay) {
     print "Readonly::XS module not found; skipping that test.\n";
-    delete $code->{roxs};
+    delete $code->{rotie};
 }
 timethese(2_000_000, $code);


### PR DESCRIPTION
In the benchmark, there's a reference to a `roxs`, but from the code it seems that it's assumed that both `&ro` and `&ro_simple` use `Readonly::XS`, whereas `&rotie` doesn't, so if `Readonly::XS` is not found, then there is no need for `&rotie` because the other two don't have `XS`.